### PR TITLE
Exercise 11.16 Skipping a commit for tagging and deployment #skip

### DIFF
--- a/.github/workflows/hello.yml
+++ b/.github/workflows/hello.yml
@@ -1,0 +1,20 @@
+name: Hello World!
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  hello-world-job:
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Say hello
+        run: |
+          echo "Hello World!"
+
+      - name: Print current date
+        run: date
+
+      - name: Print current directory content
+        run: ls -l

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -1,0 +1,49 @@
+name: Deployment pipeline
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches: [main]
+    types: [opened, synchronize]
+
+env:
+  # Release only on push/merge and only if the commit message doesn't contain '#skip'
+  RELEASE: ${{ github.event_name == 'push' && !contains(join(github.event.commits.*.message, ', '), '#skip')}}
+
+jobs:
+  simple_deployment_pipeline:
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+      - name: Install dependencies
+        run: npm install
+      - name: lint
+        run: npm run eslint
+      - name: build
+        run: npm run build
+      - name: test
+        run: npm run test
+      - uses: superfly/flyctl-actions/setup-flyctl@master
+      - name: deploy
+        if: ${{ env.RELEASE == 'true' }}
+        run: flyctl deploy --remote-only
+        env:
+          FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
+
+  tag_release:
+    if: ${{ github.env.RELEASE == 'true' }}
+    needs: [simple_deployment_pipeline] # Make sure pipeline finishes its run first
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v4
+      - name: Bump version and push tag
+        uses: anothrNick/github-tag-action@1.71.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          DEFAULT_BUMP: patch
+          # DRY_RUN: true # Use this to test the action without creating or tagging the release

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -1,0 +1,34 @@
+name: Playwright Tests
+on:
+  push:
+    branches: [main]
+  # Not running on pull requests, because it's expensive operation
+  #  and it's not explicitely required by the exercises
+jobs:
+  test:
+    timeout-minutes: 10
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 18
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Install Playwright Browsers
+        run: npx playwright install --with-deps
+
+      - name: Build
+        run: npm run build
+
+      - name: Run Playwright tests
+        run: npm run test:e2e
+
+      - uses: actions/upload-artifact@v4
+        if: ${{ !cancelled() }}
+        with:
+          name: playwright-report
+          path: playwright-report/
+          retention-days: 10


### PR DESCRIPTION
If correctly configured, there _shouldn't_ be a new version tag even after the merge